### PR TITLE
Update deploy_guidance.md

### DIFF
--- a/docs/deploy_guidance.md
+++ b/docs/deploy_guidance.md
@@ -86,6 +86,7 @@ vllm serve /path/to/step3-fp8 \
     --reasoning-parser step3 \
     --enable-auto-tool-choice \
     --tool-call-parser step3 \
+    --gpu-memory-utilization 0.85 \
     --max-num-batched-tokens 4096 \
     --trust-remote-code \
 ```


### PR DESCRIPTION
Add the setting --gpu-memory-utilization 0.85 for Data Parallelism + Tensor Parallelism(Serving on 8xH20). In case no this setting, following error will occur when deploy with Data Parallelism + Tensor Parallelism on 8 * H20 96G node:
(EngineCore_2 pid=28306) ERROR 08-06 14:37:29 [core.py:683]     raise RuntimeError(
(EngineCore_2 pid=28306) ERROR 08-06 14:37:29 [core.py:683] RuntimeError: CUDA out of memory occurred when warming up sampler with 1024 dummy requests. Please try lowering `max_num_seqs` or `gpu_memory_utilization` when initializing the engine.