### PR TITLE
Fix: replace expired / incorrect Discord invite in README with official StepFun invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </div>
 
 <div align="center" style="line-height: 1;">
-<a href="https://discord.com/invite/XHheP5Fn" target="_blank"><img alt="Discord" src="https://img.shields.io/badge/Discord-StepFun-white?logo=discord&logoColor=white"/></a>
+<a href="https://discord.com/invite/E5AthJNz" target="_blank"><img alt="Discord" src="https://img.shields.io/badge/Discord-StepFun-white?logo=discord&logoColor=white"/></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue?&color=blue"/></a>
 </div>
 


### PR DESCRIPTION
**Summary**
Replace the Discord invite link in `README.md`. The current invite in the README points to an incorrect/expired server. Based on community reports (including my work as a moderator), that server was using the StepFun name and was involved in crypto-related scam activity; it had over 1,500 members. For safety, I replaced the link with the official StepFun Discord invite published on StepFun’s official channels.
**Notes / contact**
I am a moderator for **r/LocalLLaMA** and **r/StepFun** and I helped identify this issue while reviewing links shared to our communities. If you need more context or logs from the community reports, I can provide them here in the PR discussion.